### PR TITLE
Use BIP39 for seed generation for new wallets

### DIFF
--- a/gui/qt/seed_dialog.py
+++ b/gui/qt/seed_dialog.py
@@ -78,10 +78,10 @@ class SeedLayout(QVBoxLayout):
                 else:
                     msg = ''
                 self.seed_warning.setText(msg)
-            cb_bip39 = QCheckBox(_('BIP39 seed'))
-            cb_bip39.toggled.connect(f)
-            cb_bip39.setChecked(self.is_bip39)
-            vbox.addWidget(cb_bip39)
+            #cb_bip39 = QCheckBox(_('BIP39 seed'))
+            #cb_bip39.toggled.connect(f)
+            #cb_bip39.setChecked(self.is_bip39)
+            #vbox.addWidget(cb_bip39)
 
 
 
@@ -112,7 +112,7 @@ class SeedLayout(QVBoxLayout):
         if not dialog.exec_():
             return None
         self.is_ext = cb_ext.isChecked() if 'ext' in self.options else False
-        self.is_bip39 = cb_bip39.isChecked() if 'bip39' in self.options else False
+        self.is_bip39 = True #cb_bip39.isChecked() if 'bip39' in self.options else False
         self.is_bip39_145 = cb_bip39_145.isChecked() if 'bip39_145' in self.options else False
 
     def __init__(self, seed=None, title=None, icon=True, msg=None, options=None, is_seed=None, passphrase=None, parent=None):

--- a/ios/ElectronCash/electroncash_gui/ios_native/newwallet.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/newwallet.py
@@ -636,6 +636,7 @@ class RestoreWallet1(NewWalletSeed2):
                                                              _('If you are not sure what this is, leave this field unchanged.'),
                                                              _("If you want the wallet to use legacy Bitcoin addresses use m/44'/0'/0'"),
                                                              _("If you want the wallet to use Bitcoin Cash addresses use m/44'/145'/0'")]),
+                                                             _("If you want the wallet to use SLP addresses use m/44'/245'/0'")]),
                                         onOk = onOk, placeholder = _('Derivation') + '...', text = default_derivation
                                         )
         elif seed_type == 'old':

--- a/lib/address.py
+++ b/lib/address.py
@@ -410,7 +410,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
         if len(string) > 35:
             if ":" in string:
                 addrpiece1,addrpiece2 = string.split(":")
-                if addrpiece1=="simpleledger":
+                if addrpiece1=="simpleledger" or addrpiece1=="slptest":
                    return cls.from_slpaddr_string(string)
                 else:
                     return cls.from_cashaddr_string(string)

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -374,13 +374,13 @@ class BaseWizard(object):
         k = keystore.from_master_key(text, password)
         self.on_keystore(k)
 
-    def create_standard_seed(self): self.create_seed('standard')
+    def create_standard_seed(self): self.create_seed('bip39')
 
     def create_seed(self, seed_type):
         from . import mnemonic
         self.seed_type = seed_type
         seed = mnemonic.Mnemonic('en').make_seed() # self.seed_type)
-        self.opt_bip39 = False
+        self.opt_bip39 = True
         f = lambda x: self.request_passphrase(seed, x)
         self.show_seed_dialog(run_next=f, seed_text=seed)
 

--- a/lib/base_wizard.py
+++ b/lib/base_wizard.py
@@ -237,6 +237,7 @@ class BaseWizard(object):
             _('If you are not sure what this is, leave this field unchanged.'),
             _("If you want the wallet to use legacy Bitcoin addresses use m/44'/0'/0'"),
             _("If you want the wallet to use Bitcoin Cash addresses use m/44'/145'/0'"),
+            _("If you want the wallet to use SLP addresses use m/44'/245'/0'"),
             _("The placeholder value of {} is the default derivation for {} wallets.").format(default_derivation, self.wallet_type),
         ])
         self.line_dialog(run_next=f, title=_('Derivation for {} wallet').format(self.wallet_type), message=message, default=default_derivation, test=bitcoin.is_bip32_derivation)

--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -222,6 +222,8 @@ def seed_type(x):
         return 'old'
     elif is_new_seed(x):
         return 'standard'
+    else: #TODO: ADD CHECK FOR VALID BIP39 HERE
+        return 'bip39'
     return ''
 
 is_seed = lambda x: bool(seed_type(x))

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -680,7 +680,6 @@ def hardware_keystore(d):
     raise BaseException('unknown hardware type', hw_type)
 
 def load_keystore(storage, name):
-    w = storage.get('wallet_type', 'standard')
     d = storage.get(name, {})
     t = d.get('type')
     if not t:
@@ -689,7 +688,7 @@ def load_keystore(storage, name):
         k = Old_KeyStore(d)
     elif t == 'imported':
         k = Imported_KeyStore(d)
-    elif t == 'bip32' or t == 'bip39':
+    elif t == 'bip32':
         k = BIP32_KeyStore(d)
     elif t == 'hardware':
         k = hardware_keystore(d)

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -689,7 +689,7 @@ def load_keystore(storage, name):
         k = Old_KeyStore(d)
     elif t == 'imported':
         k = Imported_KeyStore(d)
-    elif t == 'bip32':
+    elif t == 'bip32' or t == 'bip39':
         k = BIP32_KeyStore(d)
     elif t == 'hardware':
         k = hardware_keystore(d)

--- a/lib/keystore.py
+++ b/lib/keystore.py
@@ -332,7 +332,7 @@ class BIP32_KeyStore(Deterministic_KeyStore, Xpub):
 
     def dump(self):
         d = Deterministic_KeyStore.dump(self)
-        d['type'] = 'bip32'
+        d['type'] = 'bip32' 
         d['xpub'] = self.xpub
         d['xprv'] = self.xprv
         return d
@@ -749,6 +749,14 @@ def from_seed(seed, passphrase, is_p2sh):
         keystore.passphrase = passphrase
         bip32_seed = Mnemonic.mnemonic_to_seed(seed, passphrase)
         der = "m/"
+        xtype = 'standard'
+        keystore.add_xprv_from_seed(bip32_seed, xtype, der)
+    elif t == 'bip39':
+        keystore = BIP32_KeyStore({})
+        keystore.add_seed(seed)
+        keystore.passphrase = passphrase
+        bip32_seed = Mnemonic.mnemonic_to_seed(seed, passphrase)
+        der = "m/44'/245'/0'"
         xtype = 'standard'
         keystore.add_xprv_from_seed(bip32_seed, xtype, der)
     else:

--- a/lib/mnemonic.py
+++ b/lib/mnemonic.py
@@ -24,7 +24,6 @@ import unicodedata
 import string
 
 import ecdsa
-import pbkdf2
 import binascii
 
 from .util import print_error
@@ -157,7 +156,7 @@ class Mnemonic(object):
         PBKDF2_ROUNDS = 2048
         mnemonic = normalize_text(mnemonic)
         passphrase = normalize_text(passphrase)
-        return pbkdf2.PBKDF2(mnemonic, 'mnemonic' + passphrase, iterations = PBKDF2_ROUNDS, macmodule = hmac, digestmodule = hashlib.sha512).read(64)
+        return hashlib.pbkdf2_hmac('sha512', mnemonic.encode('utf-8'), b'mnemonic' + passphrase.encode('utf-8'), PBKDF2_ROUNDS, None)
 
     def mnemonic_encode(self, i):
         n = len(self.wordlist)

--- a/lib/mnemonic.py
+++ b/lib/mnemonic.py
@@ -3,26 +3,20 @@
 # Electrum - lightweight Bitcoin client
 # Copyright (C) 2014 Thomas Voegtlin
 #
-# Permission is hereby granted, free of charge, to any person
-# obtaining a copy of this software and associated documentation files
-# (the "Software"), to deal in the Software without restriction,
-# including without limitation the rights to use, copy, modify, merge,
-# publish, distribute, sublicense, and/or sell copies of the Software,
-# and to permit persons to whom the Software is furnished to do so,
-# subject to the following conditions:
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-import os
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import os, sys
 import hmac
 import math
 import hashlib
@@ -30,10 +24,11 @@ import unicodedata
 import string
 
 import ecdsa
+import pbkdf2
+import binascii
 
 from .util import print_error
 from .bitcoin import is_old_seed, is_new_seed
-from . import version
 
 # http://www.asahi-net.or.jp/~ax2s-kmtn/ref/unicode/e_asia.html
 CJK_INTERVALS = [
@@ -115,22 +110,54 @@ filenames = {
 
 
 class Mnemonic(object):
-    # Seed derivation no longer follows BIP39
+    # Seed derivation follows BIP39
     # Mnemonic phrase uses a hash based checksum, instead of a wordlist-dependent checksum
 
     def __init__(self, lang=None):
-        lang = lang or 'en'
+        lang = lang or 'english'
         print_error('language', lang)
         filename = filenames.get(lang[0:2], 'english.txt')
         self.wordlist = load_wordlist(filename)
         print_error("wordlist has %d words"%len(self.wordlist))
+    
+    @classmethod
+    def _get_directory(cls):
+        return os.path.join(os.path.dirname(__file__), 'wordlist')
+    
+    @classmethod
+    def list_languages(cls):
+        return [f.split('.')[0] for f in os.listdir(cls._get_directory()) if f.endswith('.txt')]
+
+    @classmethod
+    def normalize_string(cls, txt):
+        if isinstance(txt, str if sys.version < '3' else bytes):
+            utxt = txt.decode('utf8')
+        elif isinstance(txt, unicode if sys.version < '3' else str):  # noqa: F821
+            utxt = txt
+        else:
+            raise TypeError("String value expected")
+
+        return unicodedata.normalize('NFKD', utxt)
+
+    @classmethod
+    def detect_language(cls, code):
+        code = cls.normalize_string(code)
+        first = code.split(' ')[0]
+        languages = cls.list_languages()
+
+        for lang in languages:
+            mnemo = cls(lang)
+            if first in mnemo.wordlist:
+                return lang
+
+        raise ConfigurationError("Language not detected")
 
     @classmethod
     def mnemonic_to_seed(self, mnemonic, passphrase):
         PBKDF2_ROUNDS = 2048
         mnemonic = normalize_text(mnemonic)
         passphrase = normalize_text(passphrase)
-        return hashlib.pbkdf2_hmac('sha512', mnemonic.encode('utf-8'), b'electrum' + passphrase.encode('utf-8'), iterations = PBKDF2_ROUNDS)
+        return pbkdf2.PBKDF2(mnemonic, 'mnemonic' + passphrase, iterations = PBKDF2_ROUNDS, macmodule = hmac, digestmodule = hashlib.sha512).read(64)
 
     def mnemonic_encode(self, i):
         n = len(self.wordlist)
@@ -140,11 +167,6 @@ class Mnemonic(object):
             i = i//n
             words.append(self.wordlist[x])
         return ' '.join(words)
-
-    def get_suggestions(self, prefix):
-        for w in self.wordlist:
-            if w.startswith(prefix):
-                yield w
 
     def mnemonic_decode(self, seed):
         n = len(self.wordlist)
@@ -161,28 +183,23 @@ class Mnemonic(object):
         i = self.mnemonic_decode(seed)
         return i % custom_entropy == 0
 
-    def make_seed(self, seed_type='standard', num_bits=132, custom_entropy=1):
-        prefix = version.seed_prefix(seed_type)
-        # increase num_bits in order to obtain a uniform distibution for the last word
-        bpw = math.log(len(self.wordlist), 2)
-        num_bits = int(math.ceil(num_bits/bpw) * bpw)
-        # handle custom entropy; make sure we add at least 16 bits
-        n_custom = int(math.ceil(math.log(custom_entropy, 2)))
-        n = max(16, num_bits - n_custom)
-        print_error("make_seed", prefix, "adding %d bits"%n)
-        my_entropy = 1
-        while my_entropy < pow(2, n - bpw):
-            # try again if seed would not contain enough words
-            my_entropy = ecdsa.util.randrange(pow(2, n))
-        nonce = 0
-        while True:
-            nonce += 1
-            i = custom_entropy * (my_entropy + nonce)
-            seed = self.mnemonic_encode(i)
-            assert i == self.mnemonic_decode(seed)
-            if is_old_seed(seed):
-                continue
-            if is_new_seed(seed, prefix):
-                break
-        print_error('%d words'%len(seed.split()))
-        return seed
+    def make_seed(self, num_bits=128, custom_entropy=1):
+        if num_bits not in [128, 160, 192, 224, 256]:
+            raise ValueError('Strength should be one of the following [128, 160, 192, 224, 256], but it is not (%d).' % strength)
+        return self.to_mnemonic(os.urandom(num_bits // 8))
+
+    def to_mnemonic(self, data):
+        if len(data) not in [16, 20, 24, 28, 32]:
+            raise ValueError('Data length should be one of the following: [16, 20, 24, 28, 32], but it is not (%d).' % len(data))
+        h = hashlib.sha256(data).hexdigest()
+        b = bin(int(binascii.hexlify(data), 16))[2:].zfill(len(data) * 8) + \
+            bin(int(h, 16))[2:].zfill(256)[:len(data) * 8 // 32]
+        result = []
+        for i in range(len(b) // 11):
+            idx = int(b[i * 11:(i + 1) * 11], 2)
+            result.append(self.wordlist[idx])
+        if self.detect_language(' '.join(result)) == 'japanese':  # Japanese must be joined by ideographic space.
+            result_phrase = u'\u3000'.join(result)
+        else:
+            result_phrase = ' '.join(result)
+        return result_phrase

--- a/lib/networks.py
+++ b/lib/networks.py
@@ -75,6 +75,7 @@ class NetworkConstants:
         cls.ADDRTYPE_P2SH = 196
         cls.ADDRTYPE_P2SH_BITPAY = 196  # Unsure
         cls.CASHADDR_PREFIX = "bchtest"
+        cls.SLPADDR_PREFIX = "slptest"
         cls.HEADERS_URL = "http://bitcoincash.com/files/testnet_headers"
         cls.GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
         cls.DEFAULT_PORTS = {'t':'51001', 's':'51002'}

--- a/lib/networks.py
+++ b/lib/networks.py
@@ -60,7 +60,7 @@ class NetworkConstants:
         cls.GENESIS = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
         cls.DEFAULT_PORTS = {'t': '50001', 's': '50002'}
         cls.DEFAULT_SERVERS = read_json_dict('servers.json')
-        cls.TITLE = 'Electron Cash'
+        cls.TITLE = 'Electron Cash SLP'
 
         # Bitcoin Cash fork block specification
         cls.BITCOIN_CASH_FORK_BLOCK_HEIGHT = 478559
@@ -79,7 +79,7 @@ class NetworkConstants:
         cls.GENESIS = "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943"
         cls.DEFAULT_PORTS = {'t':'51001', 's':'51002'}
         cls.DEFAULT_SERVERS = read_json_dict('servers_testnet.json')
-        cls.TITLE = 'Electron Cash Testnet'
+        cls.TITLE = 'Electron Cash SLP Testnet'
 
         # Bitcoin Cash fork block specification
         cls.BITCOIN_CASH_FORK_BLOCK_HEIGHT = 1155876

--- a/lib/simple_config.py
+++ b/lib/simple_config.py
@@ -240,14 +240,16 @@ class SimpleConfig(PrintError):
 
     def open_last_wallet(self):
         if self.get('wallet_path') is None:
-            last_wallet = self.get('gui_last_wallet')
+            last_wallet = self.get('gui_last_wallet_slp')
             if last_wallet is not None and os.path.exists(last_wallet):
                 self.cmdline_options['default_wallet_path'] = last_wallet
 
     def save_last_wallet(self, wallet):
         if self.get('wallet_path') is None:
             path = wallet.storage.path
-            self.set_key('gui_last_wallet', path)
+            self.set_key('gui_last_wallet_slp', path)
+            if wallet.storage.get('wallet_type') != 'bip39-slp':
+                self.set_key('gui_last_wallet', path)
 
     def max_fee_rate(self):
         f = self.get('max_fee_rate', MAX_FEE_RATE)

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -2366,6 +2366,7 @@ wallet_constructors = {
     'standard': Standard_Wallet,
     'old': Standard_Wallet,
     'xpub': Standard_Wallet,
+    'bip39-slp': Standard_Wallet,
     'imported_privkey': ImportedPrivkeyWallet,
     'imported_addr': ImportedAddressWallet,
 }

--- a/lib/wallet.py
+++ b/lib/wallet.py
@@ -2270,7 +2270,7 @@ class Simple_Deterministic_Wallet(Simple_Wallet, Deterministic_Wallet):
 
 
 class Standard_Wallet(Simple_Deterministic_Wallet):
-    wallet_type = 'standard'
+    wallet_type = 'bip39-slp'
 
     def pubkeys_to_address(self, pubkey):
         return Address.from_pubkey(pubkey)
@@ -2357,7 +2357,7 @@ class Multisig_Wallet(Deterministic_Wallet):
         txin['num_sig'] = self.m
 
 
-wallet_types = ['standard', 'multisig', 'imported']
+wallet_types = ['standard', 'bip39-slp', 'multisig', 'imported']
 
 def register_wallet_type(category):
     wallet_types.append(category)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
     install_requires=[
         'pyaes>=0.1a1',
         'ecdsa>=0.9',
-        'pbkdf2',
         'requests',
         'qrcode',
         'protobuf',


### PR DESCRIPTION
* Adds new wallet type called "bip39-slp" to prevent backwards compatibility
* All new wallets seeds use bip39 seeds
* Uses BIP44 coin type 245 to derive xprv, xpub,  and addresses